### PR TITLE
Add a --message-only parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You can pass the following options via cli arguments:
 | Display version | `-v` | `--version` |
 | Application name (default: pino) | `-a` | `--appname` |
 | Echo messages to the console (default: true) | `-e` | `--echo` |
+| Only send msg property as message to papertrail (default: false) | `-m` | `--message-only` |
 | Papertrail destination address (default: localhost) | `-H` | `--host` |
 | Papertrail destination port (default: 1234) | `-p` | `--port` |
 

--- a/index.js
+++ b/index.js
@@ -17,13 +17,15 @@ const options = {
     echo: 'e',
     host: 'H',
     port: 'p',
-    appname: 'a'
+    appname: 'a',
+    'message-only': 'm'
   },
   default: {
     appname: 'pino',
     echo: true,
     host: 'localhost',
-    port: '1234'
+    port: '1234',
+    'message-only': false
   }
 }
 

--- a/lib/pino-papertrail.js
+++ b/lib/pino-papertrail.js
@@ -52,7 +52,7 @@ module.exports.toSyslog = function (options) {
       appName: options.appname,
       pid: data.pid,
       time: (data.time) ? new Date(data.time) : new Date(),
-      message: JSON.stringify(data)
+      message: options['message-only'] ? data.msg : JSON.stringify(data)
     })
     cb(null, msg)
   })

--- a/test/pino-papertrail.test.js
+++ b/test/pino-papertrail.test.js
@@ -145,6 +145,20 @@ test('parses fatal message', (t) => {
   app.stdin.end(`${messages.fatalMessage}\n`)
 })
 
+test('can forward only message to papertrail', (t) => {
+  t.plan(4)
+  const app = spawn('node', [appPath, '-m'])
+  app.stdout.on('data', (data) => {
+    const msg = data.toString()
+    t.ok(msg.startsWith('<10>1 2018'))
+    t.ok(!msg.includes('"level":60'))
+    t.ok(!msg.includes('"fatal message"'))
+    t.ok(msg.includes('fatal message'))
+    app.kill()
+  })
+  app.stdin.end(`${messages.fatalMessage}\n`)
+})
+
 test('sends to udp', (t) => {
   t.plan(2)
   const app = spawn('node', [appPath, '-e', true, '-p', '12345'])

--- a/usage.txt
+++ b/usage.txt
@@ -12,3 +12,4 @@
   -e  | --echo              echo messages to the console; default: true
   -H  | --host              the hostname of papertrail; default: localhost
   -p  | --port              the port of papertrail; default: 1234
+  -m  | --message-only      only send msg property to papertrail. default: false (=send json)


### PR DESCRIPTION
I prefer to only get the msg property sent as the message to papertrail. It makes the logs much more readable in papertrail.