### PR TITLE
auto-reconnect for tls/tcp socket error

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -38,11 +38,14 @@ const writeStream = papertrail.createWriteStream({
 
 You can pass the following properties in an options object:
 
-| Property                      | Type    | Description                                     |
-|-------------------------------|---------|-------------------------------------------------|
-| appname (default: pino)       | string  | Application name                                |
-| host (default: localhost)     | string  | Papertrail destination address                  |
-| port (default: 1234)          | number  | Papertrail destination port                     |
-| connection (default: udp)     | string  | Papertrail connection method (tls/tcp/udp)      |
-| echo (default: true)          | boolean | Echo messages to the console                    |
-| message-only (default: false) | boolean | Only send msg property as message to papertrail |
+| Property                                                | Type              | Description                                         |
+|---------------------------------------------------------|-------------------|-----------------------------------------------------|
+| appname (default: pino)                                 | string            | Application name                                    |
+| host (default: localhost)                               | string            | Papertrail destination address                      |
+| port (default: 1234)                                    | number            | Papertrail destination port                         |
+| connection (default: udp)                               | string            | Papertrail connection method (tls/tcp/udp)          |
+| echo (default: true)                                    | boolean           | Echo messages to the console                        |
+| message-only (default: false)                           | boolean           | Only send msg property as message to papertrail     |
+| backoff-strategy (default: `new ExponentialStrategy()`) | [BackoffStrategy] | Retry backoff strategy for any tls/tcp socket error |
+
+[BackoffStrategy]: https://github.com/MathieuTurcotte/node-backoff#interface-backoffstrategy

--- a/lib/pino-papertrail.js
+++ b/lib/pino-papertrail.js
@@ -10,6 +10,7 @@ const fastJsonParse = require('fast-json-parse')
 const split2 = require('split2')
 const glossy = require('glossy')
 const through2 = require('through2')
+const backoff = require('backoff')
 
 const PINO_LEVELS = { trace: 10, debug: 20, info: 30, warn: 40, error: 50, fatal: 60 }
 const SYSLOG_SEVERITIES = { emergency: 0, alert: 1, critical: 2, error: 3, warning: 4, notice: 5, info: 6, debug: 7 }
@@ -32,22 +33,37 @@ function toPapertrailTcp (options) {
   var isConnected = false
   var socket = null
 
+  // Create a socket with a retry strategy for any socket error
   function createSocket () {
-    socket = (options.connection === 'tls' ? tls : net).connect(options.port, options.host, () => {
-      isConnected = true
-      if (bufferStream.size() > 0) {
-        const b = bufferStream.getContents()
-        socket.write(b)
-      }
+    const backoffStrategy = options['backoff-strategy'] || new backoff.ExponentialStrategy()
+    backoffStrategy.reset()
+    const call = backoff.call((callback) => {
+      socket = (options.connection === 'tls' ? tls : net).connect(options.port, options.host, () => {
+        isConnected = true
+        if (bufferStream.size() > 0) {
+          const b = bufferStream.getContents()
+          socket.write(b)
+        }
+      })
+      socket.setKeepAlive(true)
+      socket.setNoDelay(true)
+      socket.on('error', (err) => {
+        isConnected = false
+        callback(err)
+      })
+      socket.on('end', () => {
+        isConnected = false
+        callback()
+        createSocket().start()
+      })
+    }, () => {})
+    call.setStrategy(backoffStrategy)
+    call.on('backoff', (num, delay, err) => {
+      console.log('Error: ' + err.message + '\nRetry in ' + delay + 'ms')
     })
-    socket.setKeepAlive(true)
-    socket.setNoDelay(true)
-    socket.on('end', () => {
-      isConnected = false
-      createSocket()
-    })
+    return call
   }
-  createSocket()
+  createSocket().start()
 
   const bufferStream = new streamBuffers.WritableStreamBuffer()
   const writableStream = new stream.Writable({

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,6 +313,14 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "requires": {
+        "precond": "0.2"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2690,6 +2698,11 @@
       "requires": {
         "find-up": "^2.1.0"
       }
+    },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "tap": "^14.6.4"
   },
   "dependencies": {
+    "backoff": "^2.5.0",
     "fast-json-parse": "^1.0.3",
     "glossy": "^0.1.7",
     "minimist": "^1.2.0",


### PR DESCRIPTION
I found that the tls/tcp connection can fail, e.g. when the free quota is used up, leading to the program to exit (ugh).

This PR adds a retry logic with default exponential backoff strategy.