### PR TITLE
Resume logging via udp after failure

### DIFF
--- a/lib/pino-papertrail.js
+++ b/lib/pino-papertrail.js
@@ -86,7 +86,10 @@ function toPapertrailUdp (options) {
     write (data, encoding, callback) {
       if (options.echo === true) { console.log(data.toString()) }
       socket.send(data, 0, data.length, options.port, options.host, function (err) {
-        callback(err)
+        if (err) {
+          console.log('error', err.message)
+        }
+        callback()
       })
     }
   })

--- a/test/pino-papertrail.test.js
+++ b/test/pino-papertrail.test.js
@@ -198,6 +198,23 @@ test('sends to udp', (t) => {
   })
 })
 
+test('logs error when DNS resolution fails', (t) => {
+  t.plan(2)
+  const app = spawn('node', [appPath, '-H', 'nosuchhost.example.com', '-e', true, '-p', '12345'])
+  app.stdout.on('data', (data) => {
+    t.ok(data.toString().startsWith('error'), 'shall log an error')
+    app.kill()
+  })
+  app.on('close', (code) => {
+    if (os.type() === 'Windows_NT') {
+      t.is(code, null)
+    } else {
+      t.is(code, 0)
+    }
+  })
+  app.stdin.end(`${messages.infoMessage}\n`)
+})
+
 test('pino-papertrail api (no option)', (t) => {
   t.plan(1)
   t.ok(api.createWriteStream(), 'should be able to pass no options')


### PR DESCRIPTION
Logs any errors received when sending UDP packets and tries again for the next message. Resolves #37

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

#### Checklist

- [ x ] run `npm run test`
- [ x ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ x ] commit message and code follows *Code Of Conduct*
