### PR TITLE
Custom hostname and log level prefix

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -9,9 +9,14 @@ const papertrail = require('pino-papertrail')
 
 const pinoms = require('pino-multi-stream')
 // create the papertrail destination stream
-const options = require('./options.json')
-const appname = 'my-project'
-const writeStream = papertrail.createWriteStream({ ...options, appname })
+const writeStream = papertrail.createWriteStream({
+  host: 'logs.papertrailapp.com',
+  port: 12345,
+  hostname: 'my-host',
+  appname: 'my-app',
+  'message-only': true,
+  'prefix-level': true
+})
 // create pino loggger
 const logger = pinoms({ streams: [{ stream: writeStream }] })
 // log some events
@@ -29,8 +34,12 @@ Example:
 
 ```js
 const writeStream = papertrail.createWriteStream({
-  ...require('/options.json'),
-  appname: 'my-project'
+  host: 'logs.papertrailapp.com',
+  port: 12345,
+  hostname: 'my-host',
+  appname: 'my-app',
+  'message-only': true,
+  'prefix-level': true
 })
 ````
 
@@ -40,12 +49,14 @@ You can pass the following properties in an options object:
 
 | Property                                                | Type              | Description                                         |
 |---------------------------------------------------------|-------------------|-----------------------------------------------------|
+| hostname (default: system hostname)                     | string            | Host name                                           |
 | appname (default: pino)                                 | string            | Application name                                    |
 | host (default: localhost)                               | string            | Papertrail destination address                      |
 | port (default: 1234)                                    | number            | Papertrail destination port                         |
 | connection (default: udp)                               | string            | Papertrail connection method (tls/tcp/udp)          |
 | echo (default: true)                                    | boolean           | Echo messages to the console                        |
 | message-only (default: false)                           | boolean           | Only send msg property as message to papertrail     |
+| prefix-level (default: false)                           | boolean           | prefix messages with the log level                  |
 | backoff-strategy (default: `new ExponentialStrategy()`) | [BackoffStrategy] | Retry backoff strategy for any tls/tcp socket error |
 
 [BackoffStrategy]: https://github.com/MathieuTurcotte/node-backoff#interface-backoffstrategy

--- a/index.js
+++ b/index.js
@@ -9,14 +9,15 @@ const defaultOptions = {
   host: 'localhost',
   port: '1234',
   connection: 'udp',
-  'message-only': false
+  'message-only': false,
+  'prefix-level': false,
 }
 
 module.exports.createWriteStream = (opts) => {
-  const { appname, echo, host, port, connection, 'message-only': messageOnly } = { ...defaultOptions, ...opts }
+  const { hostname, appname, echo, host, port, connection, 'message-only': messageOnly, 'prefix-level': prefixLevel } = { ...defaultOptions, ...opts }
 
   const parseJson = pinoPapertrail.parseJson()
-  const toSyslog = pinoPapertrail.toSyslog({ appname, 'message-only': messageOnly })
+  const toSyslog = pinoPapertrail.toSyslog({ hostname, appname, 'message-only': messageOnly, 'prefix-level': prefixLevel })
   const papertrail = pinoPapertrail.toPapertrail({ echo, port, host, connection })
 
   return pumpify(parseJson, toSyslog, papertrail)

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const defaultOptions = {
   port: '1234',
   connection: 'udp',
   'message-only': false,
-  'prefix-level': false,
+  'prefix-level': false
 }
 
 module.exports.createWriteStream = (opts) => {

--- a/lib/pino-papertrail.js
+++ b/lib/pino-papertrail.js
@@ -123,9 +123,7 @@ module.exports.toSyslog = function (options) {
       appName: options.appname,
       pid: data.pid,
       time: (data.time) ? new Date(data.time) : new Date(),
-      message: options['message-only']
-                ? (options['prefix-level'] ? `${_levelToPrefix(data.level)}: ${data.msg}` : data.msg)
-                : JSON.stringify(data)
+      message: options['message-only'] ? (options['prefix-level'] ? `${_levelToPrefix(data.level)}: ${data.msg}` : data.msg) : JSON.stringify(data)
     })
     cb(null, msg)
   })

--- a/lib/pino-papertrail.js
+++ b/lib/pino-papertrail.js
@@ -13,6 +13,7 @@ const through2 = require('through2')
 const backoff = require('backoff')
 
 const PINO_LEVELS = { trace: 10, debug: 20, info: 30, warn: 40, error: 50, fatal: 60 }
+const PINO_PREFIX = { 10: 'trace', 20: 'debug', 30: 'info', 40: 'warn', 50: 'error', 60: 'fatal' }
 const SYSLOG_SEVERITIES = { emergency: 0, alert: 1, critical: 2, error: 3, warning: 4, notice: 5, info: 6, debug: 7 }
 
 function _jsonParser (str) {
@@ -27,6 +28,10 @@ function _levelToSeverity (level) {
   if (level === PINO_LEVELS.warn) { return SYSLOG_SEVERITIES.warning }
   if (level === PINO_LEVELS.error) { return SYSLOG_SEVERITIES.error }
   return SYSLOG_SEVERITIES.critical
+}
+
+function _levelToPrefix (level) {
+  return PINO_PREFIX[level]
 }
 
 function toPapertrailTcp (options) {
@@ -114,11 +119,13 @@ module.exports.toSyslog = function (options) {
     const msg = syslogProducer.produce({
       facility: options.facility || 'user',
       severity: _levelToSeverity(data.level),
-      host: data.hostname,
+      host: options.hostname || data.hostname,
       appName: options.appname,
       pid: data.pid,
       time: (data.time) ? new Date(data.time) : new Date(),
-      message: options['message-only'] ? data.msg : JSON.stringify(data)
+      message: options['message-only']
+                ? (options['prefix-level'] ? `${_levelToPrefix(data.level)}: ${data.msg}` : data.msg)
+                : JSON.stringify(data)
     })
     cb(null, msg)
   })

--- a/lib/pino-papertrail.js
+++ b/lib/pino-papertrail.js
@@ -123,7 +123,9 @@ module.exports.toSyslog = function (options) {
       appName: options.appname,
       pid: data.pid,
       time: (data.time) ? new Date(data.time) : new Date(),
-      message: options['message-only'] ? (options['prefix-level'] ? `${_levelToPrefix(data.level)}: ${data.msg}` : data.msg) : JSON.stringify(data)
+      message: options['message-only']
+        ? (options['prefix-level'] ? `${_levelToPrefix(data.level)}: ${data.msg}` : data.msg)
+        : (options['prefix-level'] ? `${_levelToPrefix(data.level)}: ${JSON.stringify(data)}` : JSON.stringify(data))
     })
     cb(null, msg)
   })


### PR DESCRIPTION
This PR is to add support for two additional configuration options:

```js
{
  hostname: 'MyHostname',
  'prefix-level': true,
}
```

The `hostname` configuration option, allows you to set a custom hostname. Currently, this is statically defined as the system hostname, which is not always desired.

The `prefix-level` configuration option, will prefix all logs with the written log level (ie: `info:`, `error:`, etc).

These additional configuration options would allow a user to produce log output that looks like:

```js
{
  hostname: 'MyHostname',
  appname: 'MyAppName',
  'message-only': true,
  'prefix-level': true,
}

logger.info('hello world')
// Aug 23 01:43:32 MyHostname MyAppName info: hello world
```

Test Results:
```
PASS  test/pino-papertrail.test.js 59 OK 6s

🌈 SUMMARY RESULTS 🌈

Suites:   1 passed, 1 of 1 completed
Asserts:  59 passed, of 59
Time:     7s
```

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*