### PR TITLE
Call shutdown() when process.stdin ends

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -54,7 +54,7 @@ function shutdown () {
   }
 }
 
-process.on('SIGTERM', function () { shutdown() })
+//process.on('SIGTERM', function () { shutdown() })
 
 const pipeline = pumpify(parseJson, toSyslog, papertrail)
 process.stdin.pipe(pipeline)


### PR DESCRIPTION
When using `node app.js | pino-papertrail` and the application exits, pino-papertail continues to run.

This change listens for the 'end' event on process.stdin and calls shutdown().