### PR TITLE
Call shutdown() when process.stdin ends and add option to disable

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -27,8 +27,16 @@ const options = {
     host: 'localhost',
     port: '1234',
     connection: 'udp',
-    'message-only': false
-  }
+    'message-only': false,
+    'sigterm-exit': true,
+    'pipe-exit': true
+  },
+  boolean: [
+    'echo',
+    'message-only',
+    'sigterm-exit',
+    'pipe-exit'
+  ]
 }
 
 const argv = minimist(process.argv.slice(2), options)
@@ -54,7 +62,20 @@ function shutdown () {
   }
 }
 
-process.on('SIGTERM', function () { shutdown() })
+process.on('SIGTERM', function () {
+  if(!argv['sigterm-exit']) {
+    return
+  }
+  shutdown()
+})
+
+process.stdin.on('end', function () {
+  if(!argv['pipe-exit']) {
+    return
+  }
+  shutdown()
+})
 
 const pipeline = pumpify(parseJson, toSyslog, papertrail)
 process.stdin.pipe(pipeline)
+

--- a/usage.txt
+++ b/usage.txt
@@ -13,3 +13,5 @@
   -H  | --host              the hostname of papertrail; default: localhost
   -p  | --port              the port of papertrail; default: 1234
   -m  | --message-only      only send msg property to papertrail. default: false (=send json)
+  --no-sigterm-exit         prevent exit on SIGTERM
+  --no-pipe-exit            prevent exit when process.stdin ends


### PR DESCRIPTION
When using `node app.js | pino-papertrail` and the application exits, pino-papertail continues to run.

This change listens for the 'end' event on process.stdin and calls shutdown().

Two new options have been added --no-sigterm-exit and --no-pipe-exit which will override the default behaviour and prevent the shutdown.

The boolean option has also been added for minimist which allows --no-echo and --message-only.